### PR TITLE
fix project name

### DIFF
--- a/org.exist.eclipse.db.v460/.project
+++ b/org.exist.eclipse.db.v460/.project
@@ -1,6 +1,6 @@
 <?xml version="1.0" encoding="UTF-8"?>
 <projectDescription>
-	<name>org.exist.eclipse.db.v141</name>
+	<name>org.exist.eclipse.db.v460</name>
 	<comment></comment>
 	<projects>
 	</projects>


### PR DESCRIPTION
The project name tag inside `.project` was the same like the one in the `1.4.1` plugin.
This PR fixes it to `v4.6.0`.